### PR TITLE
 Allow returning multiple objects per QL message

### DIFF
--- a/lib/documents/inventory_adjustment.rb
+++ b/lib/documents/inventory_adjustment.rb
@@ -1,13 +1,19 @@
 module Documents
   class InventoryAdjustment
-    attr_reader :type
 
     def initialize(data)
-      @type = :inventory
       @data = data
     end
 
     def to_h
+      {
+        inventories: [inventory],
+      }
+    end
+
+    private
+
+    def inventory
       {
         id: @data['reference_number'],
         business_unit: @data['business_unit'],

--- a/lib/documents/purchase_order_receipt.rb
+++ b/lib/documents/purchase_order_receipt.rb
@@ -1,15 +1,21 @@
 module Documents
   class PurchaseOrderReceipt
-    attr_reader :type
 
     def initialize(xml)
       @doc = Nokogiri::XML(xml).remove_namespaces!
-      @type = :purchase_order
       @business_unit = @doc.xpath("//@BusinessUnit").first.text
       @po_number = @doc.xpath("//@PONumber").first.value
     end
 
     def to_h
+      {
+        purchase_orders: [purchase_order],
+      }
+    end
+
+    private
+
+    def purchase_order
       {
         id: @po_number,
         status: 'received',
@@ -17,8 +23,6 @@ module Documents
         line_items: assemble_items,
       }
     end
-
-    private
 
     def assemble_items
       @doc.xpath('//PoLine').collect { |child|

--- a/lib/documents/rma_result.rb
+++ b/lib/documents/rma_result.rb
@@ -1,10 +1,8 @@
 module Documents
   class RMAResult
-    attr_reader :type
 
     def initialize(xml)
       @doc  = Nokogiri::XML(xml).remove_namespaces!
-      @type = :rma
       @number = @doc.xpath("//@RMANumber").first.text
       @receipt_date = @doc.xpath("//@ReceiptDate").first.text
       @warehouse = @doc.xpath("//@Warehouse").first.text
@@ -13,6 +11,14 @@ module Documents
     end
 
     def to_h
+      {
+        rmas: [rma],
+      }
+    end
+
+    private
+
+    def rma
       {
         id: "#{@number}-#{Time.now.strftime('%Y%m%d%H%M%S%L')}",
         rma_number: @number,

--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -30,8 +30,6 @@ module Documents
       @doc = Nokogiri::XML(xml)
       @shipment_number = @doc.xpath("//@OrderNumber").first.text
       @date_shipped = @doc.xpath("//@DateShipped").first.text
-      @freight_cost = @doc.xpath("//@FreightCost").first.text
-      @carton_count = @doc.xpath("//@CartonCount").first.text
       @tracking_number = @doc.xpath('//@TrackingId').first.value
       @business_unit = @doc.xpath('//@BusinessUnit').first.value
       @warehouse = @doc.xpath("//@Warehouse").first.text

--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -54,22 +54,22 @@ module Documents
         status: 'shipped',
         business_unit: @business_unit,
         shipped_at: @date_shipped,
-        cartons: cartons_to_h,
+        cartons: cartons,
       }
     end
 
-    def cartons_to_h
+    def cartons
       cartons = @doc.xpath('ql:SOResult/ql:Carton', 'ql' => NAMESPACE)
       cartons.map do |carton|
         {
           :id => carton['CartonId'],
           :tracking => carton['TrackingId'],
-          :line_items => carton_line_items_to_h(carton),
+          :line_items => carton_line_items(carton),
         }
       end
     end
 
-    def carton_line_items_to_h(carton)
+    def carton_line_items(carton)
       contents = carton.xpath('ql:Content', 'ql' => NAMESPACE)
       contents.map do |content|
         {

--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -26,11 +26,8 @@ module Documents
   class ShipmentOrderResult
     NAMESPACE = 'http://schemas.quiettechnology.com/V2/SOResultDocument.xsd'
 
-    attr_reader :type
-
     def initialize(xml)
       @doc = Nokogiri::XML(xml)
-      @type = :shipment
       @shipment_number = @doc.xpath("//@OrderNumber").first.text
       @date_shipped = @doc.xpath("//@DateShipped").first.text
       @freight_cost = @doc.xpath("//@FreightCost").first.text
@@ -42,6 +39,14 @@ module Documents
 
     def to_h
       {
+        shipments: [shipment],
+      }
+    end
+
+    private
+
+    def shipment
+      {
         id: @shipment_number,
         # NOTE: There may multiple tracking numbers. This is just the first.
         tracking: @tracking_number,
@@ -52,8 +57,6 @@ module Documents
         cartons: cartons_to_h,
       }
     end
-
-    private
 
     def cartons_to_h
       cartons = @doc.xpath('ql:SOResult/ql:Carton', 'ql' => NAMESPACE)

--- a/quiet_logistics_endpoint.rb
+++ b/quiet_logistics_endpoint.rb
@@ -35,11 +35,17 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
       begin
         processed = processor.process_doc(msg)
       rescue Processor::UnknownDocType
+        # TODO: Have this return a 4xx/5xx code?
         result 200, "Cannot handle document of type #{msg['document_type']}"
         return
       end
 
-      add_object(processed.type.to_sym, processed.to_h)
+      processed.to_h.each do |data_type, objects|
+        objects.each do |object|
+          add_object(data_type, object)
+        end
+      end
+
       result 200, "Got Data for #{msg['document_name']}"
     rescue => e
       handle_error(e, bucket: bucket)

--- a/spec/lib/documents/rma_result_spec.rb
+++ b/spec/lib/documents/rma_result_spec.rb
@@ -12,7 +12,9 @@ module Documents
 
         expect_any_instance_of(Time).to receive("strftime").and_return("20140722132344642")
         h = described_class.new(xml).to_h
-        expect(h[:id]).to eq "1234-20140722132344642"
+        expect(h[:rmas]).to be_a Array
+        expect(h[:rmas].size).to eq 1
+        expect(h[:rmas].first[:id]).to eq "1234-20140722132344642"
       end
     end
   end

--- a/spec/lib/documents/shipment_order_result_spec.rb
+++ b/spec/lib/documents/shipment_order_result_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Documents
   describe ShipmentOrderResult do
 
-    it 'should convert a document to a hash' do
+    it '#to_h' do
       xml = <<-XML
         <?xml version="1.0" encoding="utf-8"?>
         <SOResult
@@ -52,7 +52,10 @@ module Documents
 
       result = ShipmentOrderResult.new(xml)
 
-      expect(result.to_h).to eq(
+      expect(result.to_h[:shipments]).to be_a Array
+      expect(result.to_h[:shipments].size).to eq 1
+
+      expect(result.to_h[:shipments].first).to eq(
         :id => "H13088556647",
         :tracking => "1Z1111111111111111",
         :warehouse => "DVN",


### PR DESCRIPTION
Update all the Processor classes to be able to return multiple objects per
QL message.  To support upcoming Carton changes where we will be updating
a shipment and generating one or more cartons from a single QL message.

And a couple other refactors.