### PR TITLE
Generate cartons from ShipmentOrderResult

### DIFF
--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -38,6 +38,7 @@ module Documents
     def to_h
       {
         shipments: [shipment],
+        cartons: cartons,
       }
     end
 
@@ -52,7 +53,6 @@ module Documents
         status: 'shipped',
         business_unit: @business_unit,
         shipped_at: @date_shipped,
-        cartons: cartons,
       }
     end
 
@@ -61,7 +61,11 @@ module Documents
       cartons.map do |carton|
         {
           :id => carton['CartonId'],
+          :shipment_id => @shipment_number,
           :tracking => carton['TrackingId'],
+          :warehouse => @warehouse,
+          :business_unit => @business_unit,
+          :shipped_at => @date_shipped,
           :line_items => carton_line_items(carton),
         }
       end

--- a/spec/lib/documents/shipment_order_result_spec.rb
+++ b/spec/lib/documents/shipment_order_result_spec.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 
 module Documents
   describe ShipmentOrderResult do
-
-    it '#to_h' do
-      xml = <<-XML
+    let(:xml) do
+      <<-XML
         <?xml version="1.0" encoding="utf-8"?>
         <SOResult
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -49,46 +48,80 @@ module Documents
           <Extension />
         </SOResult>
       XML
+    end
 
-      result = ShipmentOrderResult.new(xml)
+    describe '#to_h' do
+      let(:result) { ShipmentOrderResult.new(xml) }
 
-      expect(result.to_h[:shipments]).to be_a Array
-      expect(result.to_h[:shipments].size).to eq 1
+      describe 'shipments' do
+        let(:shipments) { result.to_h[:shipments] }
 
-      expect(result.to_h[:shipments].first).to eq(
-        :id => "H13088556647",
-        :tracking => "1Z1111111111111111",
-        :warehouse => "DVN",
-        :status => "shipped",
-        :business_unit => "BONOBOS",
-        :shipped_at => "2015-02-24T15:51:31.0953088Z",
-        :cartons => [
-          {
-            :id => "S11111111",
-            :tracking => "1Z1111111111111111",
-            :line_items => [
-              {
-                :ql_item_number => "1111111",
-                :quantity => 1,
-              },
-              {
-                :ql_item_number => "2222222",
-                :quantity => 1,
-              },
-            ],
-          },
-          {
-            :id => "S22222222",
-            :tracking => "1Z2222222222222222",
-            :line_items => [
-              {
-                :ql_item_number => "3333333",
-                :quantity => 1,
-              },
-            ],
-          },
-        ],
-      )
+        it 'should have the expected properties' do
+          expect(shipments).to be_a Array
+          expect(shipments.size).to eq 1
+
+          shipment = shipments.first
+
+          expect(shipment).to eq(
+            id: "H13088556647",
+            tracking: "1Z1111111111111111",
+            warehouse: "DVN",
+            status: "shipped",
+            business_unit: "BONOBOS",
+            shipped_at: "2015-02-24T15:51:31.0953088Z",
+          )
+        end
+      end
+
+      describe 'cartons' do
+        let(:cartons) { result.to_h[:cartons] }
+
+        it 'should have the expected properties' do
+          expect(cartons).to be_a Array
+          expect(cartons.size).to eq 2
+
+          carton1 = cartons.first
+          carton2 = cartons.second
+
+          expect(carton1).to eq(
+            {
+              id: "S11111111",
+              shipment_id: 'H13088556647',
+              tracking: "1Z1111111111111111",
+              warehouse: 'DVN',
+              business_unit: 'BONOBOS',
+              shipped_at: '2015-02-24T15:51:31.0953088Z',
+              line_items: [
+                {
+                  ql_item_number: "1111111",
+                  quantity: 1,
+                },
+                {
+                  ql_item_number: "2222222",
+                  quantity: 1,
+                },
+              ],
+            },
+          )
+
+          expect(carton2).to eq(
+            {
+              id: "S22222222",
+              shipment_id: 'H13088556647',
+              tracking: "1Z2222222222222222",
+              warehouse: 'DVN',
+              business_unit: 'BONOBOS',
+              shipped_at: '2015-02-24T15:51:31.0953088Z',
+              line_items: [
+                {
+                  ql_item_number: "3333333",
+                  quantity: 1,
+                },
+              ],
+            },
+          )
+        end
+      end
     end
   end
 end

--- a/spec/quiet_logistics_endpoint_spec.rb
+++ b/spec/quiet_logistics_endpoint_spec.rb
@@ -138,6 +138,14 @@ describe QuietLogisticsEndpoint do
           it { expect(subject.size).to eq 1 }
           it { expect(subject[0]['id']).to eq 'H13088556647' }
         end
+
+        describe 'cartons' do
+          subject { json_response['cartons'] }
+          before { make_request }
+
+          it { expect(subject.size).to eq 1 }
+          it { expect(subject[0]['id']).to eq 'S11111111' }
+        end
       end
     end
   end


### PR DESCRIPTION
Alongside updating the shipment, for now. Eventually we will stop updating the
shipment and just generate the cartons.