### PR TITLE
Update aws-sdk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby File.read(File.join(File.dirname(__FILE__), '.ruby-version')).strip
 
 gem 'honeybadger'
 gem 'nokogiri'
-gem 'aws-sdk'
+gem 'aws-sdk', '~>1.29'
 gem 'timecop'
 gem 'multi_json', '~> 1.0'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,11 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     addressable (2.3.7)
-    aws-sdk (1.29.1)
+    aws-sdk (1.63.0)
+      aws-sdk-v1 (= 1.63.0)
+    aws-sdk-v1 (1.63.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-      uuidtools (~> 2.1)
     byebug (2.7.0)
       columnize (~> 0.3)
       debugger-linecache (~> 1.2)
@@ -38,12 +39,14 @@ GEM
     jbuilder (2.0.6)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
-    json (1.8.0)
+    json (1.8.2)
     kgio (2.8.0)
     method_source (0.8.1)
+    mini_portile (0.6.2)
     minitest (4.7.5)
     multi_json (1.7.7)
-    nokogiri (1.5.9)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -85,7 +88,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    uuidtools (2.1.4)
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -94,7 +96,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk
+  aws-sdk (~> 1.29)
   endpoint_base!
   foreman
   honeybadger


### PR DESCRIPTION
To remove a whole bunch of deprecation warnings like:

> Digest::Digest is deprecated; use Digest

Just updating to the latest 1.X version for now to minimize the
changes.