### PR TITLE
Restore PurchaseOrderReceipt

### DIFF
--- a/lib/documents/purchase_order_receipt.rb
+++ b/lib/documents/purchase_order_receipt.rb
@@ -1,0 +1,35 @@
+module Documents
+  class PurchaseOrderReceipt
+
+    def initialize(xml)
+      @doc = Nokogiri::XML(xml).remove_namespaces!
+      @business_unit = @doc.xpath("//@BusinessUnit").first.text
+      @po_number = @doc.xpath("//@PONumber").first.value
+    end
+
+    def to_h
+      {
+        purchase_orders: [purchase_order],
+      }
+    end
+
+    private
+
+    def purchase_order
+      {
+        id: @po_number,
+        status: 'received',
+        business_unit: @business_unit,
+        line_items: assemble_items,
+      }
+    end
+
+    def assemble_items
+      @doc.xpath('//PoLine').collect { |child|
+          { line_number: child['Line'],
+            itemno: child['ItemNumber'],
+            quantity: child['ReceiveQuantity'],
+            receivedate: child['ReceiveDate'] } }
+    end
+  end
+end

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -23,6 +23,10 @@ class Processor
     case type
     when 'ShipmentOrderResult'
       Documents::ShipmentOrderResult.new(data)
+    when 'PurchaseOrderReceipt'
+      # Temporarily track whether we are actually processing these
+      Rollbar.info("Proceesing #{type.inspect}")
+      Documents::PurchaseOrderReceipt.new(data)
     when 'RMAResultDocument'
       Documents::RMAResult.new(data)
     else

--- a/spec/lib/documents/purchase_order_receipt_spec.rb
+++ b/spec/lib/documents/purchase_order_receipt_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module Documents
+  describe PurchaseOrderReceipt do
+
+    describe "#inspect" do
+      xit 'should convert po document to a message' do
+        xml = xml('123456')
+        m = PurchaseOrderReceipt.new(xml).inspect
+        m[:messages].first[:payload][:purchase_order][:items].count.should == 19
+      end
+    end
+  end
+end


### PR DESCRIPTION
Looks like we really do receive these and I shouldn't have removed this code in
4300ad811cba6558882bfe5dec6a65ea33c0c4da.  See also PR https://github.com/bonobos/quiet_logistics_integration/pull/8.

Restoring it here to un-break things.  It would be great to add some working
specs around it as soon as we can.