### PR TITLE
Serialize line items as "ql_line_items" in Wombat

### DIFF
--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -66,7 +66,7 @@ module Documents
           :warehouse => @warehouse,
           :business_unit => @business_unit,
           :shipped_at => @date_shipped,
-          :line_items => carton_line_items(carton),
+          :ql_line_items => carton_line_items(carton),
         }
       end
     end

--- a/spec/lib/documents/shipment_order_result_spec.rb
+++ b/spec/lib/documents/shipment_order_result_spec.rb
@@ -91,7 +91,7 @@ module Documents
               warehouse: 'DVN',
               business_unit: 'BONOBOS',
               shipped_at: '2015-02-24T15:51:31.0953088Z',
-              line_items: [
+              ql_line_items: [
                 {
                   ql_item_number: "1111111",
                   quantity: 1,
@@ -112,7 +112,7 @@ module Documents
               warehouse: 'DVN',
               business_unit: 'BONOBOS',
               shipped_at: '2015-02-24T15:51:31.0953088Z',
-              line_items: [
+              ql_line_items: [
                 {
                   ql_item_number: "3333333",
                   quantity: 1,


### PR DESCRIPTION
So they have a separate namespace from spree's "line items".

This depends on https://github.com/bonobos/spree-backend/pull/1133