### PR TITLE
Stop updating shipments from ShipmentOrderResults

### DIFF
--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -37,24 +37,11 @@ module Documents
 
     def to_h
       {
-        shipments: [shipment],
         quiet_logistics_cartons: cartons,
       }
     end
 
     private
-
-    def shipment
-      {
-        id: @shipment_number,
-        # NOTE: There may multiple tracking numbers. This is just the first.
-        tracking: @tracking_number,
-        warehouse: @warehouse,
-        status: 'shipped',
-        business_unit: @business_unit,
-        shipped_at: @date_shipped,
-      }
-    end
 
     def cartons
       cartons = @doc.xpath('ql:SOResult/ql:Carton', 'ql' => NAMESPACE)

--- a/spec/lib/documents/shipment_order_result_spec.rb
+++ b/spec/lib/documents/shipment_order_result_spec.rb
@@ -53,26 +53,6 @@ module Documents
     describe '#to_h' do
       let(:result) { ShipmentOrderResult.new(xml) }
 
-      describe 'shipments' do
-        let(:shipments) { result.to_h[:shipments] }
-
-        it 'should have the expected properties' do
-          expect(shipments).to be_a Array
-          expect(shipments.size).to eq 1
-
-          shipment = shipments.first
-
-          expect(shipment).to eq(
-            id: "H13088556647",
-            tracking: "1Z1111111111111111",
-            warehouse: "DVN",
-            status: "shipped",
-            business_unit: "BONOBOS",
-            shipped_at: "2015-02-24T15:51:31.0953088Z",
-          )
-        end
-      end
-
       describe 'quiet_logistics_cartons' do
         let(:cartons) { result.to_h[:quiet_logistics_cartons] }
 

--- a/spec/quiet_logistics_endpoint_spec.rb
+++ b/spec/quiet_logistics_endpoint_spec.rb
@@ -203,9 +203,6 @@ describe QuietLogisticsEndpoint do
 
           expect(json_response['summary']).to eq "Got Data for filename.xml"
 
-          expect(json_response['shipments'].size).to eq 1
-          expect(json_response['shipments'][0]['id']).to eq 'H13088556647'
-
           expect(json_response['quiet_logistics_cartons'].size).to eq 1
           expect(json_response['quiet_logistics_cartons'][0]['id']).to eq 'S11111111'
         end


### PR DESCRIPTION
Our Wombat flows have all been updated to send carton data instead of shipment
data so we don't need this anymore.

@philbirt I believe this is OK to do now but can you think of anything that this would break?