### PR TITLE
Add message_id to wombat output

### DIFF
--- a/lib/documents/purchase_order_receipt.rb
+++ b/lib/documents/purchase_order_receipt.rb
@@ -1,7 +1,8 @@
 module Documents
   class PurchaseOrderReceipt
 
-    def initialize(xml)
+    def initialize(xml, message_id)
+      @message_id = message_id
       @doc = Nokogiri::XML(xml).remove_namespaces!
       @business_unit = @doc.xpath("//@BusinessUnit").first.text
       @po_number = @doc.xpath("//@PONumber").first.value
@@ -18,6 +19,7 @@ module Documents
     def purchase_order
       {
         id: @po_number,
+        message_id: @message_id,
         status: 'received',
         business_unit: @business_unit,
         line_items: assemble_items,

--- a/lib/documents/rma_result.rb
+++ b/lib/documents/rma_result.rb
@@ -1,7 +1,8 @@
 module Documents
   class RMAResult
 
-    def initialize(xml)
+    def initialize(xml, message_id)
+      @message_id = message_id
       @doc  = Nokogiri::XML(xml).remove_namespaces!
       @number = @doc.xpath("//@RMANumber").first.text
       @receipt_date = @doc.xpath("//@ReceiptDate").first.text
@@ -21,6 +22,7 @@ module Documents
     def rma
       {
         id: "#{@number}-#{Time.now.strftime('%Y%m%d%H%M%S%L')}",
+        message_id: @message_id,
         rma_number: @number,
         business_unit: @business_unit,
         receipt_date: @receipt_date,

--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -26,7 +26,8 @@ module Documents
   class ShipmentOrderResult
     NAMESPACE = 'http://schemas.quiettechnology.com/V2/SOResultDocument.xsd'
 
-    def initialize(xml)
+    def initialize(xml, message_id)
+      @message_id = message_id
       @doc = Nokogiri::XML(xml)
       @shipment_number = @doc.xpath("//@OrderNumber").first.text
       @date_shipped = @doc.xpath("//@DateShipped").first.text
@@ -49,6 +50,7 @@ module Documents
       cartons.map do |carton|
         {
           :id => carton['CartonId'],
+          :message_id => @message_id,
           :shipment_id => @shipment_number,
           :tracking => carton['TrackingId'],
           :warehouse => @warehouse,
@@ -83,6 +85,7 @@ module Documents
         [
           {
             id: @shipment_number,
+            message_id: @message_id,
             shipment_id: @shipment_number,
             warehouse: @warehouse,
             business_unit: @business_unit,

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -8,27 +8,28 @@ class Processor
   def process_doc(msg)
     name = msg['document_name']
     type = msg['document_type']
+    message_id = msg['id']
 
     downloader = Downloader.new(@bucket)
     data = downloader.download(name)
 
     # downloader.delete_file(name)
 
-    parse_doc(type, data)
+    parse_doc(type, data, message_id)
   end
 
   private
 
-  def parse_doc(type, data)
+  def parse_doc(type, data, message_id)
     case type
     when 'ShipmentOrderResult'
-      Documents::ShipmentOrderResult.new(data)
+      Documents::ShipmentOrderResult.new(data, message_id)
     when 'PurchaseOrderReceipt'
       # Temporarily track whether we are actually processing these
       Rollbar.info("Proceesing #{type.inspect}")
-      Documents::PurchaseOrderReceipt.new(data)
+      Documents::PurchaseOrderReceipt.new(data, message_id)
     when 'RMAResultDocument'
-      Documents::RMAResult.new(data)
+      Documents::RMAResult.new(data, message_id)
     else
       raise UnknownDocType, type.inspect
     end

--- a/spec/lib/documents/purchase_order_receipt_spec.rb
+++ b/spec/lib/documents/purchase_order_receipt_spec.rb
@@ -40,7 +40,7 @@ module Documents
     end
 
     describe '#to_h' do
-      let(:result) { PurchaseOrderReceipt.new(xml) }
+      let(:result) { PurchaseOrderReceipt.new(xml, 'some-message-id') }
 
       describe 'purchase_orders' do
         let(:purchase_orders) { result.to_h[:purchase_orders] }
@@ -53,6 +53,7 @@ module Documents
 
           expect(purchase_order).to eq(
             id: "12735_AI-48069",
+            message_id: 'some-message-id',
             status: 'received',
             business_unit: 'BONOBOS',
             line_items: [

--- a/spec/lib/documents/rma_result_spec.rb
+++ b/spec/lib/documents/rma_result_spec.rb
@@ -40,7 +40,7 @@ module Documents
     end
 
     describe '#to_h' do
-      let(:result) { RMAResult.new(xml) }
+      let(:result) { RMAResult.new(xml, 'some-message-id') }
 
       describe 'rmas' do
         let(:rmas) { result.to_h[:rmas] }
@@ -55,6 +55,8 @@ module Documents
           rma = rmas.first
 
           expect(rma[:id]).to eq "H11111111111-20140722132344642"
+
+          expect(rma[:message_id]).to eq 'some-message-id'
 
           expect(rma[:rma_number]).to eq 'H11111111111'
           expect(rma[:business_unit]).to eq 'BONOBOS'

--- a/spec/lib/documents/shipment_order_result_spec.rb
+++ b/spec/lib/documents/shipment_order_result_spec.rb
@@ -53,7 +53,7 @@ module Documents
     end
 
     describe '#to_h' do
-      let(:result) { ShipmentOrderResult.new(xml) }
+      let(:result) { ShipmentOrderResult.new(xml, 'some-message-id') }
 
       describe 'quiet_logistics_cartons' do
         let(:cartons) { result.to_h[:quiet_logistics_cartons] }
@@ -68,6 +68,7 @@ module Documents
           expect(carton1).to eq(
             {
               id: "S11111111",
+              message_id: 'some-message-id',
               shipment_id: 'H13088556647',
               tracking: "1Z1111111111111111",
               warehouse: 'DVN',
@@ -89,6 +90,7 @@ module Documents
           expect(carton2).to eq(
             {
               id: "S22222222",
+              message_id: 'some-message-id',
               shipment_id: 'H13088556647',
               tracking: "1Z2222222222222222",
               warehouse: 'DVN',
@@ -118,6 +120,7 @@ module Documents
             expect(partial_short).to eq(
               {
                 id: 'H13088556647',
+                message_id: 'some-message-id',
                 shipment_id: 'H13088556647',
                 warehouse: 'DVN',
                 business_unit: 'BONOBOS',
@@ -210,7 +213,7 @@ module Documents
 
           it 'alerts us' do
             expect(Rollbar).to receive(:error).with(/QL quantity greater than 1/)
-            ShipmentOrderResult.new(xml).to_h
+            ShipmentOrderResult.new(xml, 'some-message-id').to_h
           end
         end
       end


### PR DESCRIPTION
To make it (much) easier to connect objects to messages in Wombat.

I'm about to submit code for ShipmentOrderCancelReady handing and
wanted to have this for easier debugging.
