### PR TITLE
Handle ShipmentOrderCancelReady messages

### DIFF
--- a/lib/documents/shipment_order_cancel_ready.rb
+++ b/lib/documents/shipment_order_cancel_ready.rb
@@ -1,0 +1,59 @@
+# ShipmentOrderCancelReady is the message we get when an entire order has been
+# completely cancelled.
+# Some reasons for cancellation, as per QL, include:
+#   - ADDRESS - Address Verification Failed (unlikely)
+#   - CUSTOMER - Customer Cancel (cancelled through the interface by Bonobos)
+#   - DAMAGED - Inventory Damaged
+#   - INVENTORY - Inventory Missing
+#   - REQUESTED - Requested by Customer (initiated from warehouse due to request from Bonobos)
+# Note that Sean Johnson of Quiet Logistics also told us:
+#  "Please be aware that the order cancel reason is also only meant to be
+#   informational.  In fact, a user chooses the reason when initiated at the
+#   warehouse, so they can make a mistake."
+# We are thinking we'll be OK with the occasional error there.
+class Documents::ShipmentOrderCancelReady
+  NAMESPACE = 'http://schemas.quietlogistics.com/V2/SOCancelResultDocument.xsd'
+
+  def initialize(xml, message_id)
+    @message_id = message_id
+    @doc = Nokogiri::XML(xml)
+    @shipment_number = @doc.xpath("//@OrderNumber").first.text
+    @status = @doc.xpath("//@Status").first.text
+    @reason = @doc.xpath("//@Reason").first.text
+    @date_cancelled = @doc.xpath("//@DateCancelled").first.text
+    @business_unit = @doc.xpath('//@BusinessUnit').first.value
+    @warehouse = @doc.xpath("//@Warehouse").first.text
+  end
+
+  def to_h
+    {
+      quiet_logistics_order_cancels: [
+        {
+          id: @shipment_number,
+          message_id: @message_id,
+          shipment_id: @shipment_number,
+          status: @status,
+          reason: @reason,
+          warehouse: @warehouse,
+          business_unit: @business_unit,
+          shorted_at: @date_cancelled,
+          items: full_short_items,
+        }
+      ]
+    }
+  end
+
+  private
+
+  def full_short_items
+    items = @doc.xpath('ql:SOCancelResult/ql:OrderDetails', 'ql' => NAMESPACE)
+    items.map do |item|
+      {
+        ql_item_number: item['ItemNumber'],
+        ordered: Integer(item['QuantityOrdered']),
+        available: Integer(item['QuantityAvailable']),
+      }
+    end
+  end
+
+end

--- a/lib/documents/shipment_order_cancel_ready.rb
+++ b/lib/documents/shipment_order_cancel_ready.rb
@@ -1,8 +1,8 @@
 # ShipmentOrderCancelReady is the message we get when an entire order has been
-# completely cancelled.
+# completely canceled.
 # Some reasons for cancellation, as per QL, include:
 #   - ADDRESS - Address Verification Failed (unlikely)
-#   - CUSTOMER - Customer Cancel (cancelled through the interface by Bonobos)
+#   - CUSTOMER - Customer Cancel (canceled through the interface by Bonobos)
 #   - DAMAGED - Inventory Damaged
 #   - INVENTORY - Inventory Missing
 #   - REQUESTED - Requested by Customer (initiated from warehouse due to request from Bonobos)
@@ -20,7 +20,7 @@ class Documents::ShipmentOrderCancelReady
     @shipment_number = @doc.xpath("//@OrderNumber").first.text
     @status = @doc.xpath("//@Status").first.text
     @reason = @doc.xpath("//@Reason").first.text
-    @date_cancelled = @doc.xpath("//@DateCancelled").first.text
+    @date_canceled = @doc.xpath("//@DateCancelled").first.text
     @business_unit = @doc.xpath('//@BusinessUnit').first.value
     @warehouse = @doc.xpath("//@Warehouse").first.text
   end
@@ -36,7 +36,7 @@ class Documents::ShipmentOrderCancelReady
           reason: @reason,
           warehouse: @warehouse,
           business_unit: @business_unit,
-          shorted_at: @date_cancelled,
+          canceled_at: @date_canceled,
           items: full_short_items,
         }
       ]

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -24,6 +24,8 @@ class Processor
     case type
     when 'ShipmentOrderResult'
       Documents::ShipmentOrderResult.new(data, message_id)
+    when 'ShipmentOrderCancelReady'
+      Documents::ShipmentOrderCancelReady.new(data, message_id)
     when 'PurchaseOrderReceipt'
       # Temporarily track whether we are actually processing these
       Rollbar.info("Proceesing #{type.inspect}")

--- a/spec/lib/documents/shipment_order_cancel_ready_spec.rb
+++ b/spec/lib/documents/shipment_order_cancel_ready_spec.rb
@@ -43,7 +43,7 @@ module Documents
                   reason: 'INVENTORY',
                   warehouse: 'DVN',
                   business_unit: 'BONOBOS',
-                  shorted_at: '2015-05-13T02:49:53.763125Z',
+                  canceled_at: '2015-05-13T02:49:53.763125Z',
                   items: [
                     {
                       ql_item_number: '2222222',
@@ -101,7 +101,7 @@ module Documents
                   reason: 'CUSTOMER',
                   warehouse: 'DVN',
                   business_unit: 'BONOBOS',
-                  shorted_at: '2015-05-13T02:49:53.763125Z',
+                  canceled_at: '2015-05-13T02:49:53.763125Z',
                   items: [
                     {
                       ql_item_number: '2222222',

--- a/spec/lib/documents/shipment_order_cancel_ready_spec.rb
+++ b/spec/lib/documents/shipment_order_cancel_ready_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+
+module Documents
+  describe ShipmentOrderResult do
+    let(:xml) do
+      <<-XML
+        <?xml version="1.0" encoding="utf-8"?>
+        <SOCancelResult
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            ClientId="BONOBOS"
+            BusinessUnit="BONOBOS"
+            OrderNumber="H11111111111"
+            DateCancelled="2015-05-13T02:49:53.763125Z"
+            Status="SUCCESS"
+            Reason="INVENTORY"
+            Warehouse="DVN"
+            xmlns="http://schemas.quietlogistics.com/V2/SOCancelResultDocument.xsd">
+          <OrderDetails
+              Line="1"
+              ItemNumber="2222222"
+              QuantityOrdered="1"
+              QuantityAvailable="0" />
+        </SOCancelResult>
+      XML
+    end
+
+    describe '#to_h' do
+      let(:result) { ShipmentOrderCancelReady.new(xml, 'some-message-id') }
+
+      context 'inventory short' do
+        describe 'quiet_logistics_order_cancels' do
+          let(:order_cancels) { result.to_h[:quiet_logistics_order_cancels] }
+
+          it 'should have the expected properties' do
+            expect(order_cancels).to eq(
+              [
+                {
+                  id: 'H11111111111',
+                  message_id: 'some-message-id',
+                  shipment_id: 'H11111111111',
+                  status: 'SUCCESS',
+                  reason: 'INVENTORY',
+                  warehouse: 'DVN',
+                  business_unit: 'BONOBOS',
+                  shorted_at: '2015-05-13T02:49:53.763125Z',
+                  items: [
+                    {
+                      ql_item_number: '2222222',
+                      ordered: 1,
+                      available: 0,
+                    },
+                  ],
+                },
+              ]
+            )
+          end
+        end
+      end
+
+      context 'customer short' do
+        let(:xml) do
+          <<-XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <SOCancelResult
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                ClientId="BONOBOS"
+                BusinessUnit="BONOBOS"
+                OrderNumber="H11111111111"
+                DateCancelled="2015-05-13T02:49:53.763125Z"
+                Status="SUCCESS"
+                Reason="CUSTOMER"
+                Warehouse="DVN"
+                xmlns="http://schemas.quietlogistics.com/V2/SOCancelResultDocument.xsd">
+              <OrderDetails
+                  Line="1"
+                  ItemNumber="2222222"
+                  QuantityOrdered="1"
+                  QuantityAvailable="1" />
+              <OrderDetails
+                  Line="2"
+                  ItemNumber="3333333"
+                  QuantityOrdered="1"
+                  QuantityAvailable="1" />
+            </SOCancelResult>
+          XML
+        end
+
+        describe 'quiet_logistics_order_cancels' do
+          let(:order_cancels) { result.to_h[:quiet_logistics_order_cancels] }
+
+          it 'should have the expected properties' do
+            expect(order_cancels).to eq(
+              [
+                {
+                  id: 'H11111111111',
+                  message_id: 'some-message-id',
+                  shipment_id: 'H11111111111',
+                  status: 'SUCCESS',
+                  reason: 'CUSTOMER',
+                  warehouse: 'DVN',
+                  business_unit: 'BONOBOS',
+                  shorted_at: '2015-05-13T02:49:53.763125Z',
+                  items: [
+                    {
+                      ql_item_number: '2222222',
+                      ordered: 1,
+                      available: 1,
+                    },
+                    {
+                      ql_item_number: '3333333',
+                      ordered: 1,
+                      available: 1,
+                    },
+                  ],
+                },
+              ]
+            )
+          end
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
We get these when everything in an order is short shipped. We also get
them for a few other reasons.  See the code comments.