### PR TITLE
Revert "Temporarily make the 'add_shipment' and 'add_rma' endpoints fail."

### DIFF
--- a/quiet_logistics_endpoint.rb
+++ b/quiet_logistics_endpoint.rb
@@ -56,14 +56,13 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
   end
 
   post '/add_shipment' do
-    result 500, 'Endpoint temporarily disabled to freeze inventory changes for sync across systems' # returning a 500 here since we want to sync inventory across systems, will put this back once that sync is done
-    # begin
-    #   shipment = @payload['shipment']
-    #   message  = Api.send_document('ShipmentOrder', shipment, outgoing_bucket, outgoing_queue, @config)
-    #   result 200, message
-    # rescue => e
-    #   handle_error(e)
-    # end
+    begin
+      shipment = @payload['shipment']
+      message  = Api.send_document('ShipmentOrder', shipment, outgoing_bucket, outgoing_queue, @config)
+      result 200, message
+    rescue => e
+      handle_error(e)
+    end
   end
 
   post '/add_purchase_order' do
@@ -87,14 +86,13 @@ class QuietLogisticsEndpoint < EndpointBase::Sinatra::Base
   end
 
   post '/add_rma' do
-    result 500, 'Endpoint temporarily disabled to freeze inventory changes for sync across systems' # returning a 500 here since we want to sync inventory across systems, will put this back once that sync is done
-    # begin
-    #   rma = @payload['rma']
-    #   message  = Api.send_document('RMADocument', rma, outgoing_bucket, outgoing_queue, @config)
-    #   result 200, message
-    # rescue => e
-    #   handle_error(e)
-    # end
+    begin
+      rma = @payload['rma']
+      message  = Api.send_document('RMADocument', rma, outgoing_bucket, outgoing_queue, @config)
+      result 200, message
+    rescue => e
+      handle_error(e)
+    end
   end
 
   private

--- a/spec/quiet_logistics_endpoint_spec.rb
+++ b/spec/quiet_logistics_endpoint_spec.rb
@@ -356,9 +356,8 @@ describe QuietLogisticsEndpoint do
       end
 
       before do
-        pending
-        # expect_any_instance_of(Uploader).to receive(:process).and_return("some-s3-url")
-        # allow(SecureRandom).to receive(:uuid).and_return('some-uuid')
+        expect_any_instance_of(Uploader).to receive(:process).and_return("some-s3-url")
+        allow(SecureRandom).to receive(:uuid).and_return('some-uuid')
       end
 
       specify do
@@ -486,9 +485,8 @@ describe QuietLogisticsEndpoint do
       end
 
       before do
-        pending
-        # expect_any_instance_of(Uploader).to receive(:process).and_return("some-s3-url")
-        # allow(SecureRandom).to receive(:uuid).and_return('some-uuid')
+        expect_any_instance_of(Uploader).to receive(:process).and_return("some-s3-url")
+        allow(SecureRandom).to receive(:uuid).and_return('some-uuid')
       end
 
       specify do


### PR DESCRIPTION
This reverts commit 3304b570436dfedc83dc43d4f179da2f746e4bae.